### PR TITLE
Safer oddness check

### DIFF
--- a/Polygon/src/com/sromku/polygon/Polygon.java
+++ b/Polygon/src/com/sromku/polygon/Polygon.java
@@ -184,7 +184,7 @@ public class Polygon
 			/*
 			 * If the number of intersections is odd, then the point is inside the polygon
 			 */
-			if (intersection % 2 == 1)
+			if (intersection % 2 != 0)
 			{
 				return true;
 			}


### PR DESCRIPTION
Mostly, this is to make the automated code checkers happier since intersection count should never be negative.
