### PR TITLE
Added support to add vertices as a List<Point>

### DIFF
--- a/Polygon/src/com/sromku/polygon/Polygon.java
+++ b/Polygon/src/com/sromku/polygon/Polygon.java
@@ -73,6 +73,21 @@ public class Polygon
 
 			return this;
 		}
+		
+		 /**
+         * Add vertices of the polygon as a list
+         * The list must contain vertices in correct order
+         * @param vertices the list of vertices
+         * @return The Builder
+         */
+        public Builder addVerticesAsList(List<Point> vertices)
+        {
+            for(Point point : vertices)
+            {
+                addVertex(point);
+            }
+            return this;
+        }
 
 		/**
 		 * Close the polygon shape. This will create a new side (edge) from the <b>last</b> vertex point to the <b>first</b> vertex point.


### PR DESCRIPTION
### Summary

Adding vertexes one by one is not so useful if we are to use this library in an application where we would manipulate multiple polygons. So I thought of adding the vertices as a list of vertices. This uses the internal method `addVertex(Point point).`
### Change log
- Added a new method to support adding vertices as a List<Point
