### PR TITLE
Fixes the Vertex Bug.

### DIFF
--- a/Polygon/src/com/sromku/polygon/Line.java
+++ b/Polygon/src/com/sromku/polygon/Line.java
@@ -39,19 +39,19 @@ public class Line
 	 */
 	public boolean isInside(Point point)
 	{
-        if (_end.x == _start.x) {
-            	if (point.y == _end.y) return false;
-            	float ty = (point.y - _start.y) / (_end.y - _start.y);
-            	return (ty >= 0) && (ty <= 1);
-        }
-        if (_end.y == _start.y) {
-            	if (point.x == _end.x) return false;
-            	float tx = (point.x - _start.x) / (_end.x - _start.x);
-            	return (tx >= 0) && (tx <= 1);
-        }
-        float tx = (point.x - _start.x) / (_end.x - _start.x);
-        float ty = (point.y - _start.y) / (_end.y - _start.y);
-        return (tx == ty) && (tx >= 0) && (tx <= 1);
+        	if (_end.x == _start.x) {
+            		if (point.y == _end.y) return false;
+            		float ty = (point.y - _start.y) / (_end.y - _start.y);
+            		return (ty >= 0) && (ty <= 1);
+        	}
+		if (_end.y == _start.y) {
+        	 	if (point.x == _end.x) return false;
+        	   	float tx = (point.x - _start.x) / (_end.x - _start.x);
+        	   	return (tx >= 0) && (tx <= 1);
+        	}
+        	float tx = (point.x - _start.x) / (_end.x - _start.x);
+        	float ty = (point.y - _start.y) / (_end.y - _start.y);
+        	return (tx == ty) && (tx >= 0) && (tx <= 1);
 	}
 
 	/**

--- a/Polygon/src/com/sromku/polygon/Line.java
+++ b/Polygon/src/com/sromku/polygon/Line.java
@@ -39,16 +39,19 @@ public class Line
 	 */
 	public boolean isInside(Point point)
 	{
-		float maxX = _start.x > _end.x ? _start.x : _end.x;
-		float minX = _start.x < _end.x ? _start.x : _end.x;
-		float maxY = _start.y > _end.y ? _start.y : _end.y;
-		float minY = _start.y < _end.y ? _start.y : _end.y;
-
-		if ((point.x >= minX && point.x <= maxX) && (point.y >= minY && point.y <= maxY))
-		{
-			return true;
-		}
-		return false;
+        if (_end.x == _start.x) {
+            	if (point.y == _end.y) return false;
+            	float ty = (point.y - _start.y) / (_end.y - _start.y);
+            	return (ty >= 0) && (ty <= 1);
+        }
+        if (_end.y == _start.y) {
+            	if (point.x == _end.x) return false;
+            	float tx = (point.x - _start.x) / (_end.x - _start.x);
+            	return (tx >= 0) && (tx <= 1);
+        }
+        float tx = (point.x - _start.x) / (_end.x - _start.x);
+        float ty = (point.y - _start.y) / (_end.y - _start.y);
+        return (tx == ty) && (tx >= 0) && (tx <= 1);
 	}
 
 	/**

--- a/Polygon/src/com/sromku/polygon/Line.java
+++ b/Polygon/src/com/sromku/polygon/Line.java
@@ -42,13 +42,14 @@ public class Line
         	if (_end.x == _start.x) {
             		if (point.y == _end.y) return false;
             		float ty = (point.y - _start.y) / (_end.y - _start.y);
-            		return (ty >= 0) && (ty <= 1);
+		            return (ty >= 0) && (ty <= 1);
         	}
-		if (_end.y == _start.y) {
-        	 	if (point.x == _end.x) return false;
-        	   	float tx = (point.x - _start.x) / (_end.x - _start.x);
-        	   	return (tx >= 0) && (tx <= 1);
+        	if (_end.y == _start.y) {
+            		if (point.x == _end.x) return false;
+            		float tx = (point.x - _start.x) / (_end.x - _start.x);
+            		return (tx >= 0) && (tx <= 1);
         	}
+        	if ((point.x == _end.x) && (point.y == _end.y)) return false;
         	float tx = (point.x - _start.x) / (_end.x - _start.x);
         	float ty = (point.y - _start.y) / (_end.y - _start.y);
         	return (tx == ty) && (tx >= 0) && (tx <= 1);


### PR DESCRIPTION
If the line intercepted a vertex it would count as two intersections one for each line causing an error in the parity and registering a point inside the polygon as being outside. See issue wandh raised. This passes his given text code correctly.

It specifically maintains the positions for the start and end, and tests to see if the point is the same amount of the way through the change in the x as the change in the y. But, if this point is coincident with the end it returns false. But, not if the point is coincident with the start.
