### PR TITLE
Fixes the Vertex Bug.

### DIFF
--- a/Polygon/src/com/sromku/polygon/Line.java
+++ b/Polygon/src/com/sromku/polygon/Line.java
@@ -39,17 +39,15 @@ public class Line
 	 */
 	public boolean isInside(Point point)
 	{
+        	if ((point.x == _end.x) && (point.y == _end.y)) return false;
         	if (_end.x == _start.x) {
-            		if (point.y == _end.y) return false;
             		float ty = (point.y - _start.y) / (_end.y - _start.y);
-		            return (ty >= 0) && (ty <= 1);
+            		return (ty >= 0) && (ty <= 1);
         	}
         	if (_end.y == _start.y) {
-            		if (point.x == _end.x) return false;
             		float tx = (point.x - _start.x) / (_end.x - _start.x);
             		return (tx >= 0) && (tx <= 1);
         	}
-        	if ((point.x == _end.x) && (point.y == _end.y)) return false;
         	float tx = (point.x - _start.x) / (_end.x - _start.x);
         	float ty = (point.y - _start.y) / (_end.y - _start.y);
         	return (tx == ty) && (tx >= 0) && (tx <= 1);

--- a/Polygon/src/com/sromku/polygon/Line.java
+++ b/Polygon/src/com/sromku/polygon/Line.java
@@ -39,19 +39,19 @@ public class Line
 	 */
 	public boolean isInside(Point point)
 	{
-        if (_end.x == _start.x) {
-            	if (point.y == _end.y) return false;
-            	float ty = (point.y - _start.y) / (_end.y - _start.y);
-            	return (ty >= 0) && (ty <= 1);
-        }
-        if (_end.y == _start.y) {
-            	if (point.x == _end.x) return false;
-            	float tx = (point.x - _start.x) / (_end.x - _start.x);
-            	return (tx >= 0) && (tx <= 1);
-        }
-        float tx = (point.x - _start.x) / (_end.x - _start.x);
-        float ty = (point.y - _start.y) / (_end.y - _start.y);
-        return (tx == ty) && (tx >= 0) && (tx <= 1);
+        	if (_end.x == _start.x) {
+            		if (point.y == _end.y) return false;
+            		float ty = (point.y - _start.y) / (_end.y - _start.y);
+            		return (ty >= 0) && (ty <= 1);
+        	}
+		if (_end.y == _start.y) {
+        	 	if (point.x == _end.x) return false;
+        	   	float tx = (point.x - _start.x) / (_end.x - _start.x);
+        	   	return (tx >= 0) && (tx <= 1);
+        	}
+        	float tx = (point.x - _start.x) / (_end.x - _start.x);
+        	float ty = (point.y - _start.y) / (_end.y - _start.y);
+        	return (tx == ty) && (tx >= 0) && (tx <= 1);
 	}
 
 	/**

--- a/Polygon/src/com/sromku/polygon/Line.java
+++ b/Polygon/src/com/sromku/polygon/Line.java
@@ -39,16 +39,19 @@ public class Line
 	 */
 	public boolean isInside(Point point)
 	{
-		float maxX = _start.x > _end.x ? _start.x : _end.x;
-		float minX = _start.x < _end.x ? _start.x : _end.x;
-		float maxY = _start.y > _end.y ? _start.y : _end.y;
-		float minY = _start.y < _end.y ? _start.y : _end.y;
-
-		if ((point.x >= minX && point.x <= maxX) && (point.y >= minY && point.y <= maxY))
-		{
-			return true;
-		}
-		return false;
+        if (_end.x == _start.x) {
+            	if (point.y == _end.y) return false;
+            	float ty = (point.y - _start.y) / (_end.y - _start.y);
+            	return (ty >= 0) && (ty <= 1);
+        }
+        if (_end.y == _start.y) {
+            	if (point.x == _end.x) return false;
+            	float tx = (point.x - _start.x) / (_end.x - _start.x);
+            	return (tx >= 0) && (tx <= 1);
+        }
+        float tx = (point.x - _start.x) / (_end.x - _start.x);
+        float ty = (point.y - _start.y) / (_end.y - _start.y);
+        return (tx == ty) && (tx >= 0) && (tx <= 1);
 	}
 
 	/**

--- a/Polygon/src/com/sromku/polygon/Line.java
+++ b/Polygon/src/com/sromku/polygon/Line.java
@@ -42,13 +42,14 @@ public class Line
         	if (_end.x == _start.x) {
             		if (point.y == _end.y) return false;
             		float ty = (point.y - _start.y) / (_end.y - _start.y);
-            		return (ty >= 0) && (ty <= 1);
+		            return (ty >= 0) && (ty <= 1);
         	}
-		if (_end.y == _start.y) {
-        	 	if (point.x == _end.x) return false;
-        	   	float tx = (point.x - _start.x) / (_end.x - _start.x);
-        	   	return (tx >= 0) && (tx <= 1);
+        	if (_end.y == _start.y) {
+            		if (point.x == _end.x) return false;
+            		float tx = (point.x - _start.x) / (_end.x - _start.x);
+            		return (tx >= 0) && (tx <= 1);
         	}
+        	if ((point.x == _end.x) && (point.y == _end.y)) return false;
         	float tx = (point.x - _start.x) / (_end.x - _start.x);
         	float ty = (point.y - _start.y) / (_end.y - _start.y);
         	return (tx == ty) && (tx >= 0) && (tx <= 1);


### PR DESCRIPTION
The vertex bug is because if you draw a ray through a vertex it counts as two intersections one for each line that shares that vertex. My function firstly actually checks if that point is on the line rather than within a bounding box that captures that line (which for your uses isn't wrong) but checks if the end point is coincident with the point being checked and counts that as false. You can equally fix your code by just taking that single line. As long as you say that a point coincident with either a start point or end point, but not both counts as zero we maintain odd parity for insideness.
