### PR TITLE
LICENSE file inside the JAR

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,8 +12,11 @@ jar {
     from {
         configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }
     }
+    // some static files
+    from('.') {
+        include 'LICENSE'
+    }
 }
-
 dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.11'
 }


### PR DESCRIPTION
Since Apache v2 reqires to deliver binaries only together with a LICENSE file its much easier to have it inside the JAR.
Also its a good practice to do not store IDE related files (.idea folder) inside the repo.