### PR TITLE
Remove Builder() for Kotlin support

### DIFF
--- a/src/main/java/com/snatik/polygon/Polygon.java
+++ b/src/main/java/com/snatik/polygon/Polygon.java
@@ -20,15 +20,6 @@ public class Polygon {
     }
 
     /**
-     * Get the builder of the polygon
-     *
-     * @return The builder
-     */
-    public static Builder Builder() {
-        return new Builder();
-    }
-
-    /**
      * Builder of the polygon
      *
      * @author Roman Kushnarenko (sromku@gmail.com)


### PR DESCRIPTION
The static method Builder() should be removed

- It violates against the Java naming conventions
- It is more convenient to write new Polygon.Builder() instead of Polygon.Builder()

And most important:
- It makes the library unusable with Kotlin! ( Polygon.Builder() would be an constructor invocation )